### PR TITLE
Fix urls font in references (and whole document) to fit GOST

### DIFF
--- a/tex/latex/bmstu-iu8/styles/16-IU8-references.sty
+++ b/tex/latex/bmstu-iu8/styles/16-IU8-references.sty
@@ -16,3 +16,6 @@
 \addto{\captionsrussian}{%
     \renewcommand{\contentsname}{СОДЕРЖАНИЕ}
 }
+
+% Специально изменим шрифт для URL, чтобы он соответсвовал ГОСТ и остальному тексту документа
+\renewcommand{\UrlFont}{\normalfont}


### PR DESCRIPTION
Before fix url had different font
![image](https://github.com/user-attachments/assets/2fecfd79-b461-41a9-8eb5-87f4a8401e15)

After fix urls have GOST font 
![image](https://github.com/user-attachments/assets/6a2e1cc4-ccc8-4373-a717-d721bbfdac79)
