### PR TITLE
Enforce long variant urlseen instead of short one

### DIFF
--- a/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
@@ -17,5 +17,9 @@
     \renewcommand{\contentsname}{СОДЕРЖАНИЕ}
 }
 
+\DefineBibliographyStrings{russian}{%
+  urlseen = {дата обращения},
+}
+
 % Специально изменим шрифт для URL, чтобы он соответсвовал ГОСТ и остальному тексту документа
 \renewcommand{\UrlFont}{\normalfont}


### PR DESCRIPTION
For some texlive installations urlseen 'дата обр.' where used which lead то errors in final document. This override forces long variant of urlseen command