### PR TITLE
Fix number of TestVKR issues

### DIFF
--- a/tex/latex/bmstu-iu8/styles/IU8-02-construction.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-02-construction.sty
@@ -25,17 +25,10 @@
 \renewcommand{\thestructure}{} % Убрать появление счётчика в содержании
 \titleclass{\structure}{straight}[\section]
 \titleformat{\structure}[hang]{\clearpage\normalfont\bfseries\centering}{}{0em}{}
-\titlespacing*{\structure}{0pt}{0pt}{2\baselineskip}
+\titlespacing*{\structure}{0pt}{0pt}{1em}
 \titlecontents{structure}{}{}{}{}
 \renewcommand*\l@structure{\@dottedtocline{0}{0mm}{0em}}
 
-\makeatletter
-\renewcommand*\l@section{\@dottedtocline{0}{12.5mm}{2em}}
-\renewcommand*\l@structure{\@dottedtocline{0}{12.5mm}{0em}}
-\renewcommand*\l@subsection{\@dottedtocline{1}{12.5mm}{3em}}
-\renewcommand*\l@subsubsection{\@dottedtocline{2}{12.5mm}{4em}}
-\renewcommand*\l@paragraph{\@dottedtocline{3}{12.5mm}{5em}}
-\makeatother
 
 \newcommand{\structurebreak}{\clearpage}
 \newcommand{\sectionbreak}{\clearpage}
@@ -61,6 +54,14 @@
 \titlespacing*{\subsubsection}{0pt}{2ex}{2ex}[2ex]
 \titlespacing*{\paragraph}{0pt}{2ex}{2ex}[2ex]
 \titlespacing*{\subparagraph}{0pt}{2ex}{2ex}[2ex]
+
+\makeatletter
+\renewcommand*\l@section{\@dottedtocline{0}{12.5mm}{2em}}
+\renewcommand*\l@structure{\@dottedtocline{0}{12.5mm}{0em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{12.5mm}{3em}}
+\renewcommand*\l@subsubsection{\@dottedtocline{2}{12.5mm}{4em}}
+\renewcommand*\l@paragraph{\@dottedtocline{3}{12.5mm}{5em}}
+\makeatother
 
 % 6.2.4 Если заголовок включает несколько предложений, их разделяют точками. 
 % Переносы слов в заголовках не допускаются.

--- a/tex/latex/bmstu-iu8/styles/IU8-02-construction.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-02-construction.sty
@@ -29,6 +29,14 @@
 \titlecontents{structure}{}{}{}{}
 \renewcommand*\l@structure{\@dottedtocline{0}{0mm}{0em}}
 
+\makeatletter
+\renewcommand*\l@section{\@dottedtocline{0}{12.5mm}{2em}}
+\renewcommand*\l@structure{\@dottedtocline{0}{12.5mm}{0em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{12.5mm}{3em}}
+\renewcommand*\l@subsubsection{\@dottedtocline{2}{12.5mm}{4em}}
+\renewcommand*\l@paragraph{\@dottedtocline{3}{12.5mm}{5em}}
+\makeatother
+
 \newcommand{\structurebreak}{\clearpage}
 \newcommand{\sectionbreak}{\clearpage}
 

--- a/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
@@ -17,13 +17,16 @@
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения подразделов приводят после абзацного отступа, 
 % равного двум знакам, относительно обозначения разделов.
-\renewcommand*\l@subsection{\@dottedtocline{1}{5mm}{3em}}
+\renewcommand*\l@section{\@dottedtocline{1}{5mm}{3em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{10mm}{3em}}
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения пунктов приводят после абзацного отступа, 
 % равного четырем знакам, относительно обозначения разделов.
-\renewcommand*\l@subsubsection{\@dottedtocline{2}{10mm}{4em}}
+\renewcommand*\l@subsubsection{\@dottedtocline{2}{15mm}{4em}}
 % Остальное - индуктивно
 \renewcommand*\l@paragraph{\@dottedtocline{3}{15mm}{5em}}
 
+
 \setcounter{secnumdepth}{5} % Глубина заголовков - до пятого уровня
 \setcounter{tocdepth}{2}    % Глубина содержания - до второго уровня
+

--- a/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
@@ -14,25 +14,14 @@
 ]{biblatex}
 
 \defbibenvironment{bibliography}
-  {
-    \list
+  {\list
      {}
-     {\setlength{\leftmargin}{1.25cm}%
-      \setlength{\itemindent}{0em}%
-      \setlength{\itemsep}{\bibitemsep}%
-      \setlength{\parsep}{\bibparsep}}
-  }
-  {
-    \endlist
-  }
-  {
-    \item
-    \printtext[labelnumberwidth]{
-      \printfield{labelprefix}
-      \printfield{labelnumber}
-    }
-    \addspace
-  }
+     {\setlength{\leftmargin}{1.25cm}
+      \setlength{\itemindent}{0em}
+      \setlength{\itemsep}{\bibitemsep}
+      \setlength{\parsep}{\bibparsep}}}
+  {\endlist}
+  {\item\printtext[labelnumberwidth]{\printfield{labelprefix}\printfield{labelnumber}}\addspace}
 
 \defbibheading{bibliography}[СПИСОК~ИСПОЛЬЗОВАННЫХ~ИСТОЧНИКОВ]{\structure{#1}}
 \addto{\captionsrussian}{%
@@ -45,3 +34,6 @@
 
 % Специально изменим шрифт для URL, чтобы он соответсвовал ГОСТ и остальному тексту документа
 \renewcommand{\UrlFont}{\normalfont}
+
+% Изменяем шрифт для авторов в списке литературы на обычный
+\renewcommand{\mkgostheading}[1]{\normalfont{#1}}

--- a/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
@@ -12,6 +12,28 @@
     % refsection=structure,
     % sorting=ynt,
 ]{biblatex}
+
+\defbibenvironment{bibliography}
+  {
+    \list
+     {}
+     {\setlength{\leftmargin}{1.25cm}%
+      \setlength{\itemindent}{0em}%
+      \setlength{\itemsep}{\bibitemsep}%
+      \setlength{\parsep}{\bibparsep}}
+  }
+  {
+    \endlist
+  }
+  {
+    \item
+    \printtext[labelnumberwidth]{
+      \printfield{labelprefix}
+      \printfield{labelnumber}
+    }
+    \addspace
+  }
+
 \defbibheading{bibliography}[СПИСОК~ИСПОЛЬЗОВАННЫХ~ИСТОЧНИКОВ]{\structure{#1}}
 \addto{\captionsrussian}{%
     \renewcommand{\contentsname}{СОДЕРЖАНИЕ}

--- a/tex/latex/bmstu-iu8/styles/IU8-18-extra.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-18-extra.sty
@@ -23,3 +23,18 @@
 } % Кликабельные ссылки в pdf
 
 \hbadness=10000
+
+\setlist[enumerate]{
+  leftmargin=\parindent,
+  labelindent=\parindent,
+  align=left,
+  nosep,
+}
+
+\setlist[itemize]{
+  label=\textendash,
+  leftmargin=\parindent,
+  labelindent=\parindent,
+  align=left,
+  nosep,
+}

--- a/tex/latex/bmstu-iu8/styles/IU8-20-listing.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-20-listing.sty
@@ -10,7 +10,7 @@
 
 \lstdefinestyle{IU8}{
     frame=single,
-    backgroundcolor=\color{seashell},
+    % backgroundcolor=\color{seashell},
     commentstyle=\color{blue},
     keywordstyle=\color{magenta},
     basicstyle=\ttfamily\footnotesize,
@@ -36,3 +36,25 @@
 \newcommand{\listing}[2][]{%
     \lstinputlisting[caption={\texttt{\detokenize{#2}}},#1]{#2}%
 }
+
+\lstnewenvironment{codelisting}[1][]
+{
+\lstset{
+    frame=single,
+    % backgroundcolor=\color{seashell},
+    commentstyle=\color{blue},
+    keywordstyle=\color{magenta},
+    basicstyle=\ttfamily\footnotesize,
+    breakatwhitespace=false,         
+    breaklines=true,                 
+    captionpos=tl,
+    keepspaces=false,                  
+    showspaces=false,                
+    showstringspaces=false,
+    showtabs=false,         
+    extendedchars=\true,         
+    tabsize=2,
+    #1
+}
+}
+{}


### PR DESCRIPTION
These fixes were invented by @Str1m, but were only found in correspondence in messengers. 

List of corrections:
1. Fixed the left indentation for the list of references. Now it is 1.25 cm as required by the TestVKR program
2. Fixed indentation in enumerate and itemize
3. Fixed indentation after headers for section, structure, subsection, subsubsection, paragraph