### PR TITLE
Practice reports template

### DIFF
--- a/tex/latex/bmstu-iu8/BMSTU-IU8.cls
+++ b/tex/latex/bmstu-iu8/BMSTU-IU8.cls
@@ -18,6 +18,13 @@
     применяют следующие сокращения и обозначения:}
     \def\fillTitle{\fillResearchTitle}
 }
+\DeclareOption{practice}{
+	\def\termsAndDefinitionsLine{В настоящем отчёте о практике
+		применяют следующие термины с соответствующими определениями:}
+	\def\abbreviationsLine{В настоящем отчёте о практике
+		применяют следующие сокращения и обозначения:}
+	\def\fillTitle{\fillOrdinaryTitle}
+}
 \DeclareOption{ordinary}{
 	\def\termsAndDefinitionsLine{В настоящем документе
 		применяют следующие термины с соответствующими определениями:}

--- a/tex/latex/bmstu-iu8/BMSTU-IU8.cls
+++ b/tex/latex/bmstu-iu8/BMSTU-IU8.cls
@@ -23,7 +23,7 @@
 		применяют следующие термины с соответствующими определениями:}
 	\def\abbreviationsLine{В настоящем отчёте о практике
 		применяют следующие сокращения и обозначения:}
-	\def\fillTitle{\fillOrdinaryTitle}
+	\def\fillTitle{\fillPracticeTitle}
 }
 \DeclareOption{ordinary}{
 	\def\termsAndDefinitionsLine{В настоящем документе

--- a/tex/latex/bmstu-iu8/DEPENDS.txt
+++ b/tex/latex/bmstu-iu8/DEPENDS.txt
@@ -36,3 +36,4 @@ ltablex # Here (and below) go some dependencies of dependencies
 biblatex
 ifoddpage
 relsize
+ifthen

--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -58,9 +58,16 @@
 \def\@supervisorWithDegree{\@latex@warning@no@line{No \noexpand\supervisorWithDegree given}}
 
 % Поля для заполнения титульников по летней практике
+\def\practiceKind#1{\gdef\@practiceKind{#1}}
+\def\@practiceKind{\@latex@warning@no@line{No \noexpand\practiceKind given}}
+
+\def\practiceBase#1{\gdef\@practiceBase{#1}}
+\def\@practiceBase{\@latex@warning@no@line{No \noexpand\practiceBase given}}
+
+\def\practiceType#1{\gdef\@practiceType{#1}}
+\def\@practiceType{\@latex@warning@no@line{No \noexpand\practiceType given}}
+ 
 \def\departmentSupervisor#1{\gdef\@departmentSupervisor{#1}}
-\def\@departmentSupervisor{\@latex@warning@no@line{No \noexpand\departmentSupervisor given}}
-\def\prac#1{\gdef\@departmentSupervisor{#1}}
 \def\@departmentSupervisor{\@latex@warning@no@line{No \noexpand\departmentSupervisor given}}
 
 % Поля для заполнения "обычных" отчётов
@@ -255,26 +262,33 @@
 	
 	\noindent\begin{center}
 		\centering
-		{\bfseries\fontsize{20pt}{25pt}\selectfont Отчёт по \@practiceVariant практике} \\
+		{\bfseries\fontsize{20pt}{25pt}\selectfont ОТЧЁТ~ПО~\@practiceKind~ПРАКТИКЕ}
 	\end{center}
 	
+	\bigskip
+
+	{\fontsize{12pt}{15pt}\selectfont \noindent
+		Тип пратики: \@practiceType \\
+		Название предприятия: \@practiceBase \\
+	}
 
 	\vfill
 
-{\fontsize{12pt}{15pt}\selectfont	
-	Студент: группа \@group, л.д. \@profile \@studentFullName \makeUlineStack[3.5cm]{~}{(Подпись, дата)}
+	{\fontsize{12pt}{15pt}\selectfont \noindent
+	\begin{tabular}{p{0.6\linewidth}c}
 	
-	Руководитель от предприятия: \@supervisor \makeUlineStack[3.5cm]{~}{(Подпись, дата)}
-	
-	Руководитель от кафедры: \@departmentSupervisor \makeUlineStack[3.5cm]{~}{(Подпись, дата)}
-}
-	\bigskip
-	
-	\bigskip
+		Студент: группа \@group, л.д. \@profile &\\
+		\@student & \makeUlineStack{~}{(Подпись, дата)} \\
+		
+		Руководитель от предприятия:&\\
+		\@supervisor &  \makeUlineStack{~}{(Подпись, дата)} \\		
+		Руководитель от кафедры:&\\
+		\@departmentSupervisor &  \makeUlineStack{~}{(Подпись, дата)} \\
+	\end{tabular}
+	}
 
-	\bigskip
-	
 	\vfill
+	
 	\enablescore
 	
 	\vfill 
@@ -325,6 +339,7 @@
         \CompLen{\@economicsConsultant}
         \CompLen{\@lawsConsultant}
         \CompLen{\@normController}
+        \CompLen{\@departmentSupervisor}
         
         \thispagestyle{year}
         \makeBMSTUHeader

--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -3,7 +3,7 @@
 \ProvidesPackage{IU8-10-titlepage}[2024/10/28 v1.5 Титульный лист]
 
 
-\newcommand{\@strjustify}[1]{\StrCut{#1}{\\}\csA\csB \StrSubstitute{\csA}{\space}{\hfill\space}\csB}
+\newcommand{\strjustify}[1]{\StrCut{#1}{\\}\csA\csB \StrSubstitute{\csA}{\space}{\hfill\space}\csB}
 
 % Команды для задания факультета и кафедры
 \newcommand{\faculty}[2]{\gdef\@faculty{<<#1>> (#2)}}

--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -9,7 +9,8 @@
 \providecommand{\@faculty}{<<Информатика и системы управления>> (ИУ)}
 \providecommand{\@department}{<<Информационная безопасность>> (ИУ8)}
 
-% Поля для заполнения для ВКР
+% Поля для заполнения для ВКР,
+% часть полей используется и в других титульных
 \def\student#1{\gdef\@student{#1}}
 \def\@student{\@latex@warning@no@line{No \noexpand\student given}}
 
@@ -55,6 +56,12 @@
 
 \def\supervisorWithDegree#1{\gdef\@supervisorWithDegree{#1}}
 \def\@supervisorWithDegree{\@latex@warning@no@line{No \noexpand\supervisorWithDegree given}}
+
+% Поля для заполнения титульников по летней практике
+\def\departmentSupervisor#1{\gdef\@departmentSupervisor{#1}}
+\def\@departmentSupervisor{\@latex@warning@no@line{No \noexpand\departmentSupervisor given}}
+\def\prac#1{\gdef\@departmentSupervisor{#1}}
+\def\@departmentSupervisor{\@latex@warning@no@line{No \noexpand\departmentSupervisor given}}
 
 % Поля для заполнения "обычных" отчётов
 \def\discipline#1{\gdef\@discipline{#1}}
@@ -241,6 +248,40 @@
 		\makeUlineStack[3.5cm]{~}{(Подпись, дата)} \hfill\\
 }
 
+
+\newcommand\fillPracticeTitle{
+	
+	\vfill
+	
+	\noindent\begin{center}
+		\centering
+		{\bfseries\fontsize{20pt}{25pt}\selectfont Отчёт по \@practiceVariant практике} \\
+	\end{center}
+	
+
+	\vfill
+
+{\fontsize{12pt}{15pt}\selectfont	
+	Студент: группа \@group, л.д. \@profile \@studentFullName \makeUlineStack[3.5cm]{~}{(Подпись, дата)}
+	
+	Руководитель от предприятия: \@supervisor \makeUlineStack[3.5cm]{~}{(Подпись, дата)}
+	
+	Руководитель от кафедры: \@departmentSupervisor \makeUlineStack[3.5cm]{~}{(Подпись, дата)}
+}
+	\bigskip
+	
+	\bigskip
+
+	\bigskip
+	
+	\vfill
+	\enablescore
+	
+	\vfill 
+	
+	\clearpage
+}
+
 \newcommand\fillOrdinaryTitle{
 	
 	\vfill
@@ -256,7 +297,7 @@
 	\vfill
 
 {\fontsize{12pt}{15pt}\selectfont	
-	\reverseFillingBox{Студент \hspace{\widthof{Преподаватель}-\widthof{Студент}}\makeUlineStack[\widthof{\@group}]{\@group}{(Группа)}}{\@student}
+	\reverseFillingBox{Студент \hspace{\widthof{Преподаватель}-\widthof{Студент}}\makeUlineStack[\widthof{\@group}]{\@group}{(Группа)}}{\@student} \\
 	\reverseFillingBox{Преподаватель\quad\hspace{\widthof{\@group}}}{\@supervisor}
 }
 	\bigskip

--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -2,9 +2,13 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{IU8-10-titlepage}[2024/10/28 v1.5 Титульный лист]
 
+
+\newcommand{\@strjustify}[1]{\StrCut{#1}{\\}\csA\csB \StrSubstitute{\csA}{\space}{\hfill\space}\csB}
+
 % Команды для задания факультета и кафедры
 \newcommand{\faculty}[2]{\gdef\@faculty{<<#1>> (#2)}}
 \newcommand{\department}[2]{\gdef\@department{<<#1>> (#2)}}
+
 % Дефолтные значения --- забываем, кому это было надо в первую очередь :)
 \providecommand{\@faculty}{<<Информатика и системы управления>> (ИУ)}
 \providecommand{\@department}{<<Информационная безопасность>> (ИУ8)}
@@ -133,11 +137,12 @@
         \noindent\makebox[\linewidth]{\rule{\textwidth}{2pt}} 
         \makebox[\linewidth]{\rule{\textwidth}{1pt}}
     \end{center}
-    \begin{flushleft}
-        \fontsize{12pt}{14pt}\selectfont
-        ФАКУЛЬТЕТ \tabto{3cm} \@faculty \\
-        КАФЕДРА \tabto{3cm} \@department
-    \end{flushleft}
+    {\fontsize{12pt}{14pt} \selectfont \noindent
+    \begin{tabular}{lp{0.7\linewidth}}
+        ФАКУЛЬТЕТ \tabto{3cm} & \@faculty \\
+        КАФЕДРА \tabto{3cm} & \@department
+    \end{tabular}
+    }
 }
 
 \newcommand\fillingBox[3][\maxlen]{

--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -84,9 +84,12 @@
 \newcommand{\version}[1]{\gdef\@version{Вариант #1}} % Если указан вариант, то определяем команду
 \providecommand{\@version}{~} % Если не указан вариант, то заменяем на пустоту
 
+\newcommand{\noitalicfooter}{\gdef\@italicfooter{}}
+\providecommand{\@italicfooter}{\itshape}
+
 \RequirePackage{fancyhdr}
 \fancypagestyle{year}{
-  \fancyfoot[C]{\itshape Москва, \the\year~г.}
+  \fancyfoot[C]{\@italicfooter Москва, \the\year~г.}
   \renewcommand{\headrulewidth}{0pt}
   \fancyhead{}
 }
@@ -278,12 +281,12 @@
 	\begin{tabular}{p{0.6\linewidth}c}
 	
 		Студент: группа \@group, л.д. \@profile &\\
-		\@student & \makeUlineStack{~}{(Подпись, дата)} \\
+		\@student & \makeUlineStack[0.3\linewidth]{~}{(Подпись, дата)} \\
 		
 		Руководитель от предприятия:&\\
-		\@supervisor &  \makeUlineStack{~}{(Подпись, дата)} \\		
+		\@supervisor &  \makeUlineStack[0.3\linewidth]{~}{(Подпись, дата)} \\		
 		Руководитель от кафедры:&\\
-		\@departmentSupervisor &  \makeUlineStack{~}{(Подпись, дата)} \\
+		\@departmentSupervisor &  \makeUlineStack[0.3\linewidth]{~}{(Подпись, дата)} \\
 	\end{tabular}
 	}
 

--- a/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
@@ -12,19 +12,29 @@
     \@starttoc{toc}
 }
 
+
+% Нулевой отступ в содержании (TestVKR)
+\newcommand{\zerotocindent}{\gdef\@tocindentsec{0mm} \gdef\@tocindentsubsec{0mm} \gdef\@tocindentsubsubsec{0mm}}
+
+% Дефолтные значения
+\providecommand{\@tocindentsec}{5mm}
+\providecommand{\@tocindentsubsec}{10mm}
+\providecommand{\@tocindentsubsubsec}{15mm}
+
+
 \renewcommand*\l@section{\@dottedtocline{0}{0mm}{2em}}
 \renewcommand*\l@structure{\@dottedtocline{0}{0mm}{0em}}
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения подразделов приводят после абзацного отступа, 
 % равного двум знакам, относительно обозначения разделов.
-\renewcommand*\l@section{\@dottedtocline{1}{5mm}{3em}}
-\renewcommand*\l@subsection{\@dottedtocline{1}{10mm}{3em}}
+\renewcommand*\l@section{\@dottedtocline{1}{\@tocindentsec}{3em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{\@tocindentsubsec}{3em}}
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения пунктов приводят после абзацного отступа, 
 % равного четырем знакам, относительно обозначения разделов.
-\renewcommand*\l@subsubsection{\@dottedtocline{2}{15mm}{4em}}
+\renewcommand*\l@subsubsection{\@dottedtocline{2}{\@tocindentsubsubsec}{4em}}
 % Остальное - индуктивно
-\renewcommand*\l@paragraph{\@dottedtocline{3}{15mm}{5em}}
+\renewcommand*\l@paragraph{\@dottedtocline{3}{\@tocindentsubsubsec}{5em}}
 
 
 \setcounter{secnumdepth}{5} % Глубина заголовков - до пятого уровня


### PR DESCRIPTION
### What's new

* Title page for summer practice
* `\strjustify`, `\noitalicfooter` and `\zerotocindent` macros

### Description
Title page mimics the one which is generated by delo\_bmstu\_ru in ODF format.
E.g.
<details>
![titlepage](https://github.com/user-attachments/assets/2dda7020-1a1c-45df-be26-dd8b7199f0d9)

```latex
\faculty{\strjustify{Головной учебно-исследовательский и методический центр профессиональной реабилитации лиц с ограниченными \\ возможностями здоровья инвалидов}}{ГУИМЦ}
\practiceType{ТИПОВАЯ ПРАКТИКА}
\practiceKind{ВИДОВОЙ}
\practiceBase{ГБУ ЗАО ООО <<БАЗА ПРАКТИКИ>>}
\student{Иванов Петр Сидорович}
\group{ИУ8-999}
\profile{НОМЕРЗАЧЕТКИ}
\supervisor{Петров Сидр Иванович}
\departmentSupervisor{Зайцева Анастасия Владленовна}
```
</details>

`\strjustify{... \\ ...}` allows to justify faculty name and other strings if they're too long.
E.g. 
<details>
![example1](https://github.com/user-attachments/assets/adac7a45-645c-4760-a963-ab8262b1aa7e)
</details>

`\noitalicfooter` disables italic in title page footer.

`\zerotocindent` fixes TestVKR complaining about indentation in TOC (fix first introduced by @slagov in private discussion)
E.g.
<details>
![example2](https://github.com/user-attachments/assets/7331d9bc-0960-424b-99be-ecfd74296466)
</details>

### Why 'Draft PR'
a) Nothing is tested against real Leviev's system.
b) I want to make a package to generate tech task from Redmine issues.
c) Docs have to be updated accordingly.