### PR TITLE
fix(BMSTU-IU8): new diploma abbreviations rules

### DIFF
--- a/tex/latex/bmstu-iu8/BMSTU-IU8.cls
+++ b/tex/latex/bmstu-iu8/BMSTU-IU8.cls
@@ -5,10 +5,8 @@
 \LoadClass{article}
 
 \DeclareOption{diploma}{
-    \def\termsAndDefinitionsLine{В настоящем отчете о выпускной квалификационной работе специалиста
-    применяют следующие термины с соответствующими определениями:}
-    \def\abbreviationsLine{В настоящем отчете о выпускной квалификационной работе специалиста
-    применяют следующие сокращения и обозначения:}
+    \def\termsAndDefinitionsLine{В настоящей ВКР применяют следующие термины с соответствующими определениями:}
+    \def\abbreviationsLine{В настоящей ВКР применяют следующие сокращения и обозначения:}
     \def\fillTitle{\fillDiplomaTitle}
 }
 \DeclareOption{research}{

--- a/tex/latex/bmstu-iu8/styles/IU8-15-list-of-abbreviations.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-15-list-of-abbreviations.sty
@@ -18,7 +18,7 @@
 }
 
 \newcommand{\listofabbreviations}{
-    \structure{ПЕРЕЧЕНЬ~СОКРАЩЕНИЙ~И~ОБОЗНАЧЕНИЙ}
+    \structure{СПИСОК~ОБОЗНАЧЕНИЙ~И~СОКРАЩЕНИЙ}
 
     \abbreviationsLine
 


### PR DESCRIPTION
В соответствии с новым положением о порядке подготовки и зашиты ВКР:

1. Наименование структурного элемента с сокращениями:
```diff
- \structure{ПЕРЕЧЕНЬ~СОКРАЩЕНИЙ~И~ОБОЗНАЧЕНИЙ}
+ \structure{СПИСОК~ОБОЗНАЧЕНИЙ~И~СОКРАЩЕНИЙ}
```

2. Описано, как должен начинаться данный пункт (п.9.3, стр.19):
> СПИСОК ОБОЗНАЧЕНИЙ И СОКРАЩЕНИЙ начинают со слов: "В настоящей ВКР применяют следующие сокращения и обозначения".

[Положение_о_порядке_подготовки_и_защиты_ВКР.pdf](https://github.com/user-attachments/files/19038120/_._._._._._.pdf)
