### PR TITLE
Adjust indentation and alignment on contents page

### DIFF
--- a/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
@@ -17,14 +17,14 @@
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения подразделов приводят после абзацного отступа, 
 % равного двум знакам, относительно обозначения разделов.
-\renewcommand*\l@section{\@dottedtocline{1}{5mm}{3em}}
-\renewcommand*\l@subsection{\@dottedtocline{1}{10mm}{3em}}
+\renewcommand*\l@section{\@dottedtocline{1}{0mm}{3em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{0mm}{5em}}
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения пунктов приводят после абзацного отступа, 
 % равного четырем знакам, относительно обозначения разделов.
-\renewcommand*\l@subsubsection{\@dottedtocline{2}{15mm}{4em}}
+\renewcommand*\l@subsubsection{\@dottedtocline{2}{0mm}{7em}}
 % Остальное - индуктивно
-\renewcommand*\l@paragraph{\@dottedtocline{3}{15mm}{5em}}
+\renewcommand*\l@paragraph{\@dottedtocline{3}{0mm}{9em}}
 
 
 \setcounter{secnumdepth}{5} % Глубина заголовков - до пятого уровня


### PR DESCRIPTION
# Проблема
При создании отчета с исходниками в текущей master ветке, актуальный TestVkr (сборка 227) ругается на размеры левого поля или отступ абзаца на странице содержания

# Решение
Еще когда писал отчеты в Word, такая проблема всегда лечилась выравниваем номеров всех пунктов содержания (подразделы, главы и т.д.) по левому краю на уровне с разделами (например, РЕФЕРАТ, ВВЕДЕНИЕ), при этом сохраняя отступы перед названиями пунктов. По сути все оставалось так же, но номера (1, 1.2, 2, 2.2 ...) насильно "приклеивались" к левому краю

# Что изменилось
Сейчас реализовал такое же приседание, как описано в Решении: убрал отступы перед номерами пунктов, "добавив" эти отступы к отступам между номерами пунктов и их названиями

# Тестирование
На той же версии TestVkr (сборка 227) проблемное замечание пропало (ранее тестировал на версии 226, проблема тоже уходила)

## До
![old-ver](https://github.com/user-attachments/assets/2015c9a2-c887-490a-970e-4fcdeaa33e99)
![photo_2025-04-03 04 24 56](https://github.com/user-attachments/assets/6e9e1264-babb-4f65-8870-e2cd80ac2671)

## После
![new-ver](https://github.com/user-attachments/assets/92ae2f12-b3ab-4534-a0f2-5122b4edf77a)
![photo_2025-04-03 04 25 29](https://github.com/user-attachments/assets/a6688046-1b02-4109-8507-8cf89710ec02)
