### PR TITLE
Исправление для многострочных названий факультетов и кафедр

### DIFF
--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -119,8 +119,10 @@
     \end{center}
     \begin{flushleft}
         \fontsize{12pt}{14pt}\selectfont
-        ФАКУЛЬТЕТ \tabto{3cm} \@faculty \\
-        КАФЕДРА \tabto{3cm} \@department
+		\begin{tabularx}{\linewidth}{Xp{0.75\linewidth}}
+            ФАКУЛЬТЕТ \tabto{3cm} & \@faculty \\
+            КАФЕДРА \tabto{3cm} & \@department
+        \end{tabularx}
     \end{flushleft}
 }
 

--- a/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-10-titlepage.sty
@@ -71,6 +71,9 @@
 \newcommand{\version}[1]{\gdef\@version{Вариант #1}} % Если указан вариант, то определяем команду
 \providecommand{\@version}{~} % Если не указан вариант, то заменяем на пустоту
 
+\newcommand{\counttitlepage}{\gdef\@counttitlepage{ \stepcounter{page} }}
+\providecommand{\@counttitlepage}{}
+
 \RequirePackage{fancyhdr}
 \fancypagestyle{year}{
   \fancyfoot[C]{\itshape Москва, \the\year~г.}
@@ -295,4 +298,5 @@
 
         \clearpage
     \end{titlepage}
+    \@counttitlepage
 }

--- a/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-13-contents.sty
@@ -12,19 +12,29 @@
     \@starttoc{toc}
 }
 
+
+% Нулевой отступ в содержании (TestVKR)
+\newcommand{\zerotocindent}{\gdef\@tocindentsec{0mm} \gdef\@tocindentsubsec{0mm} \gdef\@tocindentsubsubsec{0mm}}
+
+% Дефолтные значения
+\providecommand{\@tocindentsec}{5mm}
+\providecommand{\@tocindentsubsec}{10mm}
+\providecommand{\@tocindentsubsubsec}{15mm}
+
+
 \renewcommand*\l@section{\@dottedtocline{0}{0mm}{2em}}
 \renewcommand*\l@structure{\@dottedtocline{0}{0mm}{0em}}
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения подразделов приводят после абзацного отступа, 
 % равного двум знакам, относительно обозначения разделов.
-\renewcommand*\l@section{\@dottedtocline{1}{5mm}{3em}}
-\renewcommand*\l@subsection{\@dottedtocline{1}{10mm}{3em}}
+\renewcommand*\l@section{\@dottedtocline{1}{\@tocindentsec}{3em}}
+\renewcommand*\l@subsection{\@dottedtocline{1}{\@tocindentsubsec}{3em}}
 % ГОСТ 7.32-2017. Пункт 5.4.1:
 % Обозначения пунктов приводят после абзацного отступа, 
 % равного четырем знакам, относительно обозначения разделов.
-\renewcommand*\l@subsubsection{\@dottedtocline{2}{15mm}{4em}}
+\renewcommand*\l@subsubsection{\@dottedtocline{2}{\@tocindentsubsubsec}{4em}}
 % Остальное - индуктивно
-\renewcommand*\l@paragraph{\@dottedtocline{3}{15mm}{5em}}
+\renewcommand*\l@paragraph{\@dottedtocline{3}{\@tocindentsubsubsec}{5em}}
 
 
 \setcounter{secnumdepth}{5} % Глубина заголовков - до пятого уровня


### PR DESCRIPTION
### Проблема
В заголовке титульного листа есть небольшая проблема с многострочными названиями факультета и/или кафедры. Всё, что не умещается в одну строку, идёт как обычный текст, т.е. попадает на вторую (третью и т.д.) строку под слово "ФАКУЛЬТЕТ".

### Решение
Я предлагаю исправить это с помощью оборачивания в таблицу (точнее в окружение `tabularx`) с фиксированной шириной правого столбца.

### Пример
Для наглядности пример с ГУИМЦ. Было:
<img width="824" height="285" alt="изображение" src="https://github.com/user-attachments/assets/b2a2dff7-5472-4fb2-b2ad-921f03b72aed" />

Стало:
<img width="789" height="310" alt="изображение" src="https://github.com/user-attachments/assets/59e678f1-13cd-47fc-b50a-d0934d1d4a9b" />

