### PR TITLE
Исправление отступов в списках

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: CatInCosmicSpace/latex-template/actions/miktex@master
 
@@ -29,7 +29,7 @@ jobs:
           latexmk -c ./main.tex
 
       - name: "Git artifact: PDF"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PDF
           path: |

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -12,7 +12,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: 'Get tag'
         run: |
@@ -43,7 +43,7 @@ jobs:
           zip -r bmstu-iu8.zip ./bmstu-iu8/
       
       - name: "Git artifact: CTAN zip"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CTAN zip
           path: |

--- a/actions/miktex/action.yaml
+++ b/actions/miktex/action.yaml
@@ -25,9 +25,11 @@ runs:
         sudo miktex --admin packages update-package-database
         sudo miktex --admin packages update
         sudo miktex packages update
+        sudo miktex packages install xkeyval
 
     - name: Update MikTeX (user)
       shell: bash
       run: |
         miktex packages update-package-database
         miktex packages update
+        miktex packages install xkeyval

--- a/actions/miktex/action.yaml
+++ b/actions/miktex/action.yaml
@@ -22,11 +22,12 @@ runs:
     - name: Update MikTeX (admin)
       shell: bash
       run: |
-        sudo mpm --admin --find-updates
-        sudo mpm --admin --update
+        sudo miktex --admin packages update-package-database
+        sudo miktex --admin packages update
+        sudo miktex packages update
 
     - name: Update MikTeX (user)
       shell: bash
       run: |
-        mpm --find-updates
-        mpm --update
+        miktex packages update-package-database
+        miktex packages update

--- a/tex/latex/bmstu-iu8/DEPENDS.txt
+++ b/tex/latex/bmstu-iu8/DEPENDS.txt
@@ -36,3 +36,4 @@ ltablex # Here (and below) go some dependencies of dependencies
 biblatex
 ifoddpage
 relsize
+xkeyval # glossaries dependency

--- a/tex/latex/bmstu-iu8/styles/IU8-04-section-numbering.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-04-section-numbering.sty
@@ -33,20 +33,33 @@
 \AddEnumerateCounter{\Asbuk}{\@Asbuk}{А}
 \AddEnumerateCounter{\asbuk}{\@asbuk}{а}
 
+
 \setlist[enumerate]{
-    leftmargin=\parindent+\labelwidth+\labelsep,
     labelindent=\parindent,
+    itemindent=\parindent+\labelwidth+\labelsep,
+    leftmargin=0cm,
     align=left,
     nosep,
 }
-\setlist[itemize]{
-    label=\textendash, 
-    leftmargin=\parindent+\labelwidth+\labelsep,
-    labelindent=\parindent,
-    align=left,
-    nosep,
-}
+% Отступ для элементов равен 0, поэтому вручную добавляем отступ для сторки с маркером
+\setlist[enumerate,2]{itemindent=\labelwidth+\labelsep+2\parindent}
+\setlist[enumerate,3]{itemindent=\labelwidth+\labelsep+3\parindent}
+\setlist[enumerate,4]{itemindent=\labelwidth+\labelsep+4\parindent}
+
 \setlist[enumerate, 1]{label=\asbuk*)}
 \setlist[enumerate, 2]{label=\arabic*)}
 \setlist[enumerate, 3]{label=\alph*)}
 \setlist[enumerate, 4]{label=\roman*)}
+
+\setlist[itemize]{
+    label=\textendash,
+    labelindent=\parindent,
+    itemindent=\parindent+\labelwidth+\labelsep,
+    leftmargin=0cm,
+    align=left,
+    nosep,
+}
+\setlist[itemize,2]{itemindent=\labelwidth+\labelsep+2\parindent}
+\setlist[itemize,3]{itemindent=\labelwidth+\labelsep+3\parindent}
+\setlist[itemize,4]{itemindent=\labelwidth+\labelsep+4\parindent}
+

--- a/tex/latex/bmstu-iu8/styles/IU8-04-section-numbering.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-04-section-numbering.sty
@@ -33,7 +33,7 @@
 \AddEnumerateCounter{\Asbuk}{\@Asbuk}{А}
 \AddEnumerateCounter{\asbuk}{\@asbuk}{а}
 
-
+% Настройка нумерованных списков
 \setlist[enumerate]{
     labelindent=\parindent,
     itemindent=\parindent+\labelwidth+\labelsep,
@@ -41,16 +41,13 @@
     align=left,
     nosep,
 }
-% Отступ для элементов равен 0, поэтому вручную добавляем отступ для сторки с маркером
-\setlist[enumerate,2]{itemindent=\labelwidth+\labelsep+2\parindent}
-\setlist[enumerate,3]{itemindent=\labelwidth+\labelsep+3\parindent}
-\setlist[enumerate,4]{itemindent=\labelwidth+\labelsep+4\parindent}
-
 \setlist[enumerate, 1]{label=\asbuk*)}
-\setlist[enumerate, 2]{label=\arabic*)}
-\setlist[enumerate, 3]{label=\alph*)}
-\setlist[enumerate, 4]{label=\roman*)}
+% Отступ для элементов равен 0, поэтому вручную добавляем отступ для сторки с маркером
+\setlist[enumerate,2]{itemindent=\labelwidth+\labelsep+2\parindent, label=\arabic*)}
+\setlist[enumerate,3]{itemindent=\labelwidth+\labelsep+3\parindent, label=\alph*)}
+\setlist[enumerate,4]{itemindent=\labelwidth+\labelsep+4\parindent, label=\roman*)}
 
+% Настройка маркированных списков
 \setlist[itemize]{
     label=\textendash,
     labelindent=\parindent,
@@ -62,4 +59,3 @@
 \setlist[itemize,2]{itemindent=\labelwidth+\labelsep+2\parindent}
 \setlist[itemize,3]{itemindent=\labelwidth+\labelsep+3\parindent}
 \setlist[itemize,4]{itemindent=\labelwidth+\labelsep+4\parindent}
-

--- a/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-16-references.sty
@@ -16,8 +16,8 @@
 \defbibenvironment{bibliography}
   {\list
      {}
-     {\setlength{\leftmargin}{1.25cm}
-      \setlength{\itemindent}{0em}
+     {\setlength{\leftmargin}{0em}
+      \setlength{\itemindent}{1.25cm}
       \setlength{\itemsep}{\bibitemsep}
       \setlength{\parsep}{\bibparsep}}}
   {\endlist}

--- a/tex/latex/bmstu-iu8/styles/IU8-18-extra.sty
+++ b/tex/latex/bmstu-iu8/styles/IU8-18-extra.sty
@@ -23,18 +23,3 @@
 } % Кликабельные ссылки в pdf
 
 \hbadness=10000
-
-\setlist[enumerate]{
-  leftmargin=\parindent,
-  labelindent=\parindent,
-  align=left,
-  nosep,
-}
-
-\setlist[itemize]{
-  label=\textendash,
-  leftmargin=\parindent,
-  labelindent=\parindent,
-  align=left,
-  nosep,
-}


### PR DESCRIPTION
## Описание проблемы
На текущей версии машинный НК проходится без проблем. Но при ручной проверке Зайцева была недовольна оформлением списков, так как расстояние между маркером и левым полем должно быть 1,25 см, а оно у нас немного (раза в два) меньше.

Также она сказала, что последующие строки (если элемент многострочный) должны иметь нулевой отступ, т.е. они должны начинаться от поля.

При попытке исправить исходники я обнаружил, что изначально было прописано именно 1,25 см в файле `IU8-04-section-numbering.sty`. Но в #8 было добавлено переопределение форматирования в файле `IU8-18-extra.sty`, которое было призвано убрать проблему со списками при машинном НК (версии 2024 года).

Проблема предыдущих вариантов видится в том, что вторая строка элемента начинается с отступа от левого поля или расстояние между маркером и полем не кратно 1,25 см.

## Решение
Чтобы решить проблему я убрал переопределение из `IU8-18-extra.sty` и изменил параметры списков так, чтобы вне зависимости от уровня вторая строка начиналась без отступа от поля.

Помимо этого я изменил параметры списка использованных источников, чтобы он соответствовал данному воззрению на отступы.

Отчёт с данным изменением проходит проверку в TestVkr v229.


## TODO:
- [x] прогнать TestVkr
- [ ] прогнать настоящий нормоконтроль

Так что нужны добровольцы и (или) доступ к настоящему НК :)